### PR TITLE
Add support for Trump's twitter handle name: realDonaldTrump

### DIFF
--- a/snugglyTrump.js
+++ b/snugglyTrump.js
@@ -36,7 +36,7 @@ const kittyName = randomKittyName();
 const kittyImageUrl = randomKittyImageUrl();
 
 document.body.innerHTML = document.body.innerHTML
-.replace(/href=".*?"|<img.*?src=".*?".*?>|Donald John Trump|Donald J. Trump|Donald Trump|The Donald|DonaldJTrump|DonaldTrump|Donald|Mr. Trump|Trump Tower|Trump|border wall|wall|tower|refugees|Mexico|Mexicans|Mexican|voter fraud|republicans|republican/ig,
+.replace(/href=".*?"|<img.*?src=".*?".*?>|Donald John Trump|Donald J. Trump|Donald Trump|The Donald|DonaldJTrump|DonaldTrump|Donald|Mr. Trump|Trump Tower|Trump|realDonaldTrump|border wall|wall|tower|refugees|Mexico|Mexicans|Mexican|voter fraud|republicans|republican/ig,
 (match) => {
   if (match.startsWith('href')) return match;
 


### PR DESCRIPTION
Unfortunately the use case of Donald Trump's twitter handle name was not covered by this library.
This pull request fixes this issue.

> Use case: https://twitter.com/realDonaldTrump